### PR TITLE
optimize CI workflow and add preparation script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,8 @@ jobs:
         run: pnpm check
 
   build:
-    name: Build
+    name: Build & Validate
     runs-on: ubuntu-22.04
-    needs: [lint]
 
     steps:
       - uses: actions/checkout@v6
@@ -65,45 +64,22 @@ jobs:
         with:
           node-version: "22"
           cache: "pnpm"
-
-      - name: Install production dependencies
-        run: pnpm install --frozen-lockfile --prod
-
-      - name: Build site
-        run: pnpm build
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: site-build
-          path: dist/
-          retention-days: 1
-
-  validate:
-    name: Validate HTML
-    runs-on: ubuntu-22.04
-    needs: [build]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: site-build
-          path: dist/
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Prepare source for CI build
+        run: >-
+          pnpm prepare-ci
+          --limit-posts 10
+          --skip-og
+          --limit-locales
+          --base-sha ${{ github.event.pull_request.base.sha }}
+
+      - name: Build site
+        env:
+          SKIP_IMAGE_OPTIMIZATION: "true"
+        run: pnpm build
 
       - name: Validate built HTML
         run: pnpm exec htmlhint 'dist/**/*.html'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ RUN pnpm install --frozen-lockfile
 
 # Prepare source
 FROM base AS src
-ARG LIMIT_POSTS
+ARG PREPARE_CI_ARGS
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN if [ -n "$LIMIT_POSTS" ]; then \
-      find src/content/blog -maxdepth 1 -name '[^_]*.md' | sort -r | tail -n +$((LIMIT_POSTS + 1)) | while IFS= read -r f; do rm -f "$f"; done; \
+RUN if [ -n "$PREPARE_CI_ARGS" ]; then \
+      CI=true pnpm prepare-ci $PREPARE_CI_ARGS; \
     fi
 
 # Build the site (static)

--- a/README.md
+++ b/README.md
@@ -112,11 +112,20 @@ Then open [http://127.0.0.1:4321](http://127.0.0.1:4321).
 
 | Arg                        | Description                                         | Example |
 | :------------------------- | :-------------------------------------------------- | :------ |
-| `LIMIT_POSTS`              | Keep only the N most recent blog posts for previews | `6`     |
+| `PREPARE_CI_ARGS`          | Arguments for the CI preparation script             | `--limit-posts 6 --skip-og` |
 | `SKIP_IMAGE_OPTIMIZATION`  | Disable image processing for faster builds          | `true`  |
 
+`PREPARE_CI_ARGS` are passed to `scripts/prepare-ci-build.ts`:
+
+| Flag               | Description                                              |
+| :----------------- | :------------------------------------------------------- |
+| `--limit-posts N`  | Keep only the N most recent blog posts                   |
+| `--skip-og`        | Remove OpenGraph image generation                        |
+| `--limit-locales`  | Build only the default locale (+ locales with PR changes)|
+| `--base-sha SHA`   | Git SHA to diff against for preserving changed content   |
+
 ```bash
-docker build --build-arg LIMIT_POSTS=6 --build-arg SKIP_IMAGE_OPTIMIZATION=true --target serve-ssr -t monero-site-ssr .
+docker build --build-arg PREPARE_CI_ARGS="--limit-posts 6 --skip-og" --build-arg SKIP_IMAGE_OPTIMIZATION=true --target serve-ssr -t monero-site-ssr .
 ```
 
 ## More

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint:css": "stylelint \"src/**/*.{css,astro}\"",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "prepare-ci": "tsx scripts/prepare-ci-build.ts"
   },
   "dependencies": {
     "@astrojs/node": "^9.5.4",

--- a/scripts/prepare-ci-build.ts
+++ b/scripts/prepare-ci-build.ts
@@ -86,10 +86,6 @@ if (args["limit-posts"]) {
   for (const file of allPosts) {
     if (keep.has(file)) continue;
     rmSync(join(BLOG_DIR, file));
-    rmSync(join(BLOG_DIR, "assets", file.slice(0, -3)), {
-      recursive: true,
-      force: true,
-    });
     removed++;
   }
 

--- a/scripts/prepare-ci-build.ts
+++ b/scripts/prepare-ci-build.ts
@@ -1,0 +1,118 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+import { parseArgs } from "node:util";
+import { defaultLocale, locales, rtlLocales } from "../src/i18n/config";
+
+if (process.env.CI !== "true") {
+  console.log("Not in CI");
+  process.exit(0);
+}
+
+const { values: args } = parseArgs({
+  options: {
+    "limit-posts": { type: "string" },
+    "skip-og": { type: "boolean", default: false },
+    "limit-locales": { type: "boolean", default: false },
+    "base-sha": { type: "string" },
+  },
+});
+
+const BLOG_DIR = "src/content/blog";
+const OG_ROUTE = "src/pages/open-graph/[...route].ts";
+const I18N_CONFIG = "src/i18n/config.ts";
+const I18N_DIR = "src/i18n/translations";
+
+function git(...gitArgs: string[]): string {
+  return execFileSync("git", gitArgs, { encoding: "utf-8" }).trim();
+}
+
+function getChangedFiles(baseSha: string, ...dirs: string[]): string[] {
+  try {
+    git("fetch", "origin", "--depth=1", baseSha);
+    return git("diff", "--name-only", baseSha, "--", ...dirs)
+      .split("\n")
+      .filter(Boolean);
+  } catch (e) {
+    console.warn("Could not detect changed files");
+    console.warn(e instanceof Error ? e.message : e);
+    return [];
+  }
+}
+
+function changedFilesUnder(dir: string): string[] {
+  return changed.filter((f) => f.startsWith(dir + "/"));
+}
+
+function serializeI18nConfig(activeLocales: Set<string>): string {
+  const entries = Object.entries(locales)
+    .filter(([key]) => activeLocales.has(key))
+    .map(([key, val]) => `  ${key}: "${val}",`);
+
+  const rtl = rtlLocales.map((l) => `"${l}"`).join(", ");
+
+  return [
+    `export const defaultLocale = "${defaultLocale}";`,
+    "export const locales = {",
+    ...entries,
+    "};",
+    `export const rtlLocales = [${rtl}];`,
+    "",
+  ].join("\n");
+}
+
+const changed = args["base-sha"]
+  ? getChangedFiles(args["base-sha"], BLOG_DIR, I18N_DIR)
+  : [];
+
+// Limit blog posts, keeping edited ones
+if (args["limit-posts"]) {
+  const limit = Number(args["limit-posts"]);
+  if (!Number.isFinite(limit) || limit < 1) {
+    console.error(`Invalid --limit-posts value: ${args["limit-posts"]}`);
+    process.exit(1);
+  }
+
+  const isPost = (f: string) => /^\d/.test(f) && f.endsWith(".md");
+
+  const allPosts = readdirSync(BLOG_DIR).filter(isPost).sort().reverse();
+  const keep = new Set(allPosts.slice(0, limit));
+
+  for (const file of changedFilesUnder(BLOG_DIR)) {
+    if (isPost(basename(file))) keep.add(basename(file));
+  }
+
+  let removed = 0;
+  for (const file of allPosts) {
+    if (keep.has(file)) continue;
+    rmSync(join(BLOG_DIR, file));
+    rmSync(join(BLOG_DIR, "assets", file.slice(0, -3)), {
+      recursive: true,
+      force: true,
+    });
+    removed++;
+  }
+
+  console.log(
+    `Blog: kept ${allPosts.length - removed} of ${allPosts.length} posts`,
+  );
+}
+
+// Limit locales
+if (args["limit-locales"]) {
+  const keepLocales = new Set([defaultLocale]);
+
+  for (const file of changedFilesUnder(I18N_DIR)) {
+    const locale = relative(I18N_DIR, file).split("/")[0];
+    if (locale && locale !== defaultLocale) keepLocales.add(locale);
+  }
+
+  writeFileSync(I18N_CONFIG, serializeI18nConfig(keepLocales));
+  console.log(`Locales: building ${Array.from(keepLocales).join(" ")}`);
+}
+
+// OpenGraph removal
+if (args["skip-og"]) {
+  rmSync(OG_ROUTE, { force: true });
+  console.log(`OpenGraph: removed ${OG_ROUTE}`);
+}


### PR DESCRIPTION
- merged the separate "Build" and "Validate" CI jobs into a single "Build & Validate" job, removing artifact upload/download steps. Lint and Build now run in parallel
- added a new `prepare-ci` script (`scripts/prepare-ci-build.ts`) for fine-grained control over which blog posts and locales are included, whether OpenGraph image generation runs, and preserving edited content in PRs via base SHA diffing
- Updated the Dockerfile to use a new `PREPARE_CI_ARGS` build argument (replacing `LIMIT_POSTS`) and to call the new preparation script during builds
- Updated README.md to document PREPARE_CI_ARGS, its available flags